### PR TITLE
Fix prop wrapping

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2215,12 +2215,12 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
               | Labelled label, e -> fmt_labelled label e
               | Optional label, e -> fmt_labelled ~prefix:"?" label e
             in
-            str " " $ hvbox 0 (list props (break 1 0) fmt_prop)
+            space_break $ hvbox 0 (list props (break 1 0) fmt_prop)
         in
         begin match !children with
-        | None -> hvbox 2 (start_tag () $ props $ str " />")
+        | None -> hvbox 2 (start_tag () $ props) $ space_break $ str "/>"
         | Some (children_loc, []) when not (Cmts.has_after c.cmts children_loc) ->
-          hvbox 2 (start_tag () $ props $ str " />")
+          hvbox 2 (start_tag () $ props) $ space_break $ str "/>"
         | Some (children_loc, children) ->
           let head = hvbox 2 (start_tag () $ props $ str ">") in
           let children =

--- a/test/mlx/mlx.t
+++ b/test/mlx/mlx.t
@@ -61,6 +61,44 @@ Children wrapping:
     <div className="some" className="another" /> some child
   </div>
 
+Prop punning:
+  $ echo '<div className />' | fmt --margin=50
+  <div className />
+
+  $ echo '<div className=className />' | fmt --margin=50
+  <div className />
+
+Children wrapping:
+  $ echo '<div><div className="some" className="another" />some child</div>' | fmt --margin=50
+  <div>
+    <div className="some" className="another" />
+    some
+    child
+  </div>
+
+Children wrapping:
+  $ echo '<div><div className="some" className="another" />some child</div>' | fmt --margin=60
+  <div>
+    <div className="some" className="another" /> some child
+  </div>
+
+Optional props:
+  $ echo '<div ?className />' | fmt --margin=50
+  <div ?className />
+
+  $ echo '<div ?className=className />' | fmt --margin=50
+  <div ?className />
+
+Props expressions:
+  $ echo '<div className=1 />' | fmt --margin=50
+  <div className=1 />
+  $ echo '<div className=(not x) />' | fmt --margin=50
+  <div className=(not x) />
+  $ echo '<div className=(1+1) />' | fmt --margin=50
+  <div className=(1 + 1) />
+  $ echo '<div className=!a />' | fmt --margin=50
+  <div className=!a />
+
 Uident:
   $ echo '<App />' | fmt
   <App />

--- a/test/mlx/mlx.t
+++ b/test/mlx/mlx.t
@@ -15,42 +15,45 @@ Basics:
   <div>child1 child2</div>
 
 Prop wrapping:
-  $ echo '<div className="some" className="another" className="third" />' | fmt --margin=50
-  <div className="some"
-       className="another"
-       className="third" />
+  $ echo '<main className="some" className="another" className="third" />' | fmt --margin=50
+  <main
+    className="some"
+    className="another"
+    className="third"
+  />
 
-Prop punning:
-  $ echo '<div className />' | fmt --margin=50
-  <div className />
-
-  $ echo '<div className=className />' | fmt --margin=50
-  <div className />
-
-Optional props:
-  $ echo '<div ?className />' | fmt --margin=50
-  <div ?className />
-
-  $ echo '<div ?className=className />' | fmt --margin=50
-  <div ?className />
-
-Props expressions:
-  $ echo '<div className=1 />' | fmt --margin=50
-  <div className=1 />
-  $ echo '<div className=(not x) />' | fmt --margin=50
-  <div className=(not x) />
-  $ echo '<div className=(1+1) />' | fmt --margin=50
-  <div className=(1 + 1) />
-  $ echo '<div className=!a />' | fmt --margin=50
-  <div className=!a />
-
-Children wrapping:
-  $ echo '<div><div className="some" className="another" />some child</div>' | fmt --margin=50
-  <div>
-    <div className="some" className="another" />
-    some
-    child
+  $ echo '<div className="some" className="another" className="third" ><div className="some" className="another" className="third" /></div>' | fmt --margin=50
+  <div
+    className="some"
+    className="another"
+    className="third">
+    <div
+      className="some"
+      className="another"
+      className="third"
+    />
   </div>
+
+  $ echo '<div><div className="some" className="another" className="third" /></div>' | fmt --margin=50
+  <div>
+    <div
+      className="some"
+      className="another"
+      className="third"
+    />
+  </div>
+
+Prop wrapping with comments:
+  $ echo '<body><div (* this className is nice *) className="some" className=("another" (* this className is not *)) className="third" /></body>' | fmt --margin=50
+  <body>
+    <div
+      (* this className is nice *)
+      className="some"
+      className="another"
+                (* this className is not *)
+      className="third"
+    />
+  </body>
 
 Children wrapping:
   $ echo '<div><div className="some" className="another" />some child</div>' | fmt --margin=60


### PR DESCRIPTION
```
<div
  className="some"
  className="another"
  className="third">
  <div
    className="some"
    className="another"
    className="third"
  />
</div>
```