### PR TITLE
Add parents when it's a JSX expression

### DIFF
--- a/test/mlx/mlx.t
+++ b/test/mlx/mlx.t
@@ -172,3 +172,11 @@ Test for a lexer hack:
   [ <element>1</element> ]
   $ echo '[<M.element> 1 </M.element>]' | fmt
   [ <M.element>1</M.element> ]
+
+JSX elements as props:
+  $ echo 'let _ = <div element=(<span />) />' | fmt
+  let _ = <div element=(<span />) />
+  $ echo 'let _ = <div element=(<Componient />) />' | fmt
+  let _ = <div element=(<Componient />) />
+  $ echo 'let _ = <Big element=(<Component />) />' | fmt
+  let _ = <Big element=(<Component />) />

--- a/test/mlx/mlx.t
+++ b/test/mlx/mlx.t
@@ -180,3 +180,15 @@ JSX elements as props:
   let _ = <div element=(<Componient />) />
   $ echo 'let _ = <Big element=(<Component />) />' | fmt
   let _ = <Big element=(<Component />) />
+
+  $ echo 'let _ = <Big>(<Component />)</Big>' | fmt
+  let _ = <Big><Component /></Big>
+
+  $ echo 'let _ = <Big>(React.string children)</Big>' | fmt
+  let _ = <Big>(React.string children)</Big>
+
+  $ echo 'let _ = <Big>(match x with | A -> "33" | B -> "44")</Big>' | fmt
+  let _ = <Big>(match x with A -> "33" | B -> "44")</Big>
+
+  $ echo 'let _ = <Big>(<Lola />)</Big>' | fmt
+  let _ = <Big><Lola /></Big>


### PR DESCRIPTION
Before it removed the parens, causing invalid syntax
```let make ~children = <LabeledInput labelElement=(<Icon.Edit />) />```
```
ocamlformat-mlx: Cannot process "src/components/ProjectInfoEditor.mlx".
  Please report this bug at https://github.com/ocaml-ppx/ocamlformat/issues.
  BUG: generating invalid ocaml syntax.
```

This PR checks if it's a JSX expr and adds them
```
$ echo 'let _ = <div element=(<span />) />' | fmt
let _ = <div element=(<span />) />
$ echo 'let _ = <div element=(<Componient />) />' | fmt
let _ = <div element=(<Componient />) />
$ echo 'let _ = <Big element=(<Component />) />' | fmt
let _ = <Big element=(<Component />) />
```