### PR TITLE
Classify JSX expressions (decide if JSX was added after or before)

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -64,6 +64,8 @@ let is_jsx_element e =
   | [{attr_name={txt="JSX";_}; attr_payload=PStr []; _}] -> true
   | _ -> false
 
+module Jsx = Ocamlformat_parser_extended.Jsx_helper
+
 type block =
   { opn: Fmt.t option
   ; pro: Fmt.t option
@@ -2278,39 +2280,13 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
              $ fmt_expression c ~box (sub_exp ~ctx e)
              $ fmt_atrs ) )
   | Pexp_apply (e0, e1N1) -> (
-      match pexp_attributes with
-      | [{attr_name={txt="JSX";loc=_}; attr_payload=PStr []; _}] ->
-        let children = ref None in
-        let props = List.filter_map e1N1 ~f:(function
-          | Labelled {txt="children";_}, {pexp_desc=Pexp_list es;pexp_loc;_} ->
-            children := Some (pexp_loc, es);
-            None
-          | Nolabel, {pexp_desc=Pexp_construct ({txt=Lident "()";_}, _); _} -> None
-          | arg -> Some arg)
-        in
-        let start_tag, end_tag =
-          let name, name_loc, id =
-            match e0.pexp_desc with
-            | Pexp_ident {txt=Lident name;loc} -> name, loc, None
-            | Pexp_ident {txt=Ldot (id, name);loc=_} -> name.txt, e0.pexp_loc, Some id
-            | _ -> failwith "JSX element tag is not Longident.t"
-          in
-          let make tag =
-            (fun () ->
-              str (Printf.sprintf "<%s" tag) $ Cmts.fmt_after c name_loc),
-            (fun () -> str (Printf.sprintf "</%s>" tag))
-          in
-          match id with
-          | None -> make name
-          | Some id ->
-            let path = Ocamlformat_ocaml_common.Longident.flatten id.txt in
-            match name with
-            | "createElement" -> make (String.concat ~sep:"." path)
-            | name -> make (Printf.sprintf "%s.%s" (String.concat ~sep:"." path) name)
-        in
+      match Jsx.classify_element ~attrs:pexp_attributes e0 e1N1 with
+      | Some {Jsx.tag; tag_loc; props; children_loc; children} ->
+        let start_tag = str ("<" ^ tag) $ Cmts.fmt_after c tag_loc in
+        let end_tag = str ("</" ^ tag ^ ">") in
         let props =
           match props with
-          | [] -> str ""
+          | [] -> noop
           | props ->
             let fmt_labelled ?(prefix="") label e =
               let flabel = str (Printf.sprintf "%s%s" prefix label.txt) in
@@ -2324,18 +2300,17 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                   flabel $ str "=" $ fmt_expression c (sub_exp ~ctx e)
             in
             let fmt_prop = function
-              | Nolabel, e -> fmt_expression c (sub_exp ~ctx e)
+              | Nolabel, _ -> assert false (* excluded by classification *)
               | Labelled label, e -> fmt_labelled label e
               | Optional label, e -> fmt_labelled ~prefix:"?" label e
             in
             space_break $ hvbox 0 (list props (break 1 0) fmt_prop)
         in
-        begin match !children with
-        | None -> hvbox 2 (start_tag () $ props) $ space_break $ str "/>"
-        | Some (children_loc, []) when not (Cmts.has_after c.cmts children_loc) ->
-          hvbox 2 (start_tag () $ props) $ space_break $ str "/>"
-        | Some (children_loc, children) ->
-          let head = hvbox 2 (start_tag () $ props $ str ">") in
+        begin match children with
+        | [] when not (Cmts.has_after c.cmts children_loc) ->
+          hvbox 2 (start_tag $ props) $ space_break $ str "/>"
+        | children ->
+          let head = hvbox 2 (start_tag $ props $ str ">") in
           let children =
             hvbox 0 (
               list children (break 1 0)
@@ -2346,9 +2321,9 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                   fmt_expression c (sub_exp ~ctx e))
               $ Cmts.fmt_after c children_loc)
           in
-          hvbox 2 (head $ break 0 0 $ children $ break 0 (-2) $ end_tag ())
+          hvbox 2 (head $ break 0 0 $ children $ break 0 (-2) $ end_tag)
         end
-      | _ ->
+      | None ->
       let wrap =
         if c.conf.fmt_opts.wrap_fun_args.v then hovbox 2 else hvbox 2
       in

--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -29,6 +29,21 @@ let docstring (c : Conf.t) =
 let sort_attributes : attributes -> attributes =
   List.sort ~compare:Poly.compare
 
+(* JSX syntax parses to an application with the unlabelled [()] argument
+   first and [~children] second. Hand-written [@JSX] applications may use
+   any other order (e.g. [App.createElement ~children:[] ()]) and are
+   canonicalized when printed with JSX syntax, so the argument order is
+   normalized before comparing ASTs. *)
+let sort_jsx_args args =
+  let arg_index (lbl, arg) =
+    match (lbl, arg.pexp_desc) with
+    | Asttypes.Nolabel, Pexp_construct ({txt= Lident "()"; _}, None) -> 0
+    | Asttypes.Labelled "children", _ -> 1
+    | _ -> 2
+  in
+  List.stable_sort args ~compare:(fun a b ->
+      Int.compare (arg_index a) (arg_index b) )
+
 let make_mapper conf ~ignore_doc_comments =
   let open Ast_helper in
   (* remove locations *)
@@ -92,6 +107,11 @@ let make_mapper conf ~ignore_doc_comments =
           (Exp.sequence ~loc:loc1 ~attrs:attrs1
              (Exp.sequence ~loc:loc2 ~attrs:attrs2 exp1 exp2)
              exp3 )
+    | Pexp_apply (e0, args)
+      when List.exists attrs1 ~f:(fun a ->
+               String.equal a.attr_name.txt "JSX" ) ->
+        Ast_mapper.default_mapper.expr m
+          {exp with pexp_desc= Pexp_apply (e0, sort_jsx_args args)}
     | _ -> Ast_mapper.default_mapper.expr m exp
   in
   let pat (m : Ast_mapper.mapper) pat =

--- a/test/mlx/mlx.t
+++ b/test/mlx/mlx.t
@@ -281,3 +281,33 @@ Raw identifiers in JSX:
   let _ = <element loading=`\#lazy />
   $ echo 'let _ = <\#foo />' | fmt
   let _ = <\#foo />
+
+Hand-written [@JSX] applications are canonicalized to JSX syntax when
+expressible (ocaml-mlx/ocamlformat-mlx#12):
+  $ echo 'let _ = ReactDOM.Client.render root ((App.createElement ~children:[] ()) [@JSX ])' | fmt
+  let _ = ReactDOM.Client.render root <App />
+  $ echo 'let _ = ((App.createElement ~children:[x; y] ()) [@JSX])' | fmt
+  let _ = <App>x y</App>
+  $ echo 'let _ = ((App.createElement ~children:[] ~foo:1 ?bar ()) [@JSX])' | fmt
+  let _ = <App foo=1 ?bar />
+  $ echo 'let _ = ((div ~children:[] ()) [@JSX])' | fmt
+  let _ = <div />
+  $ echo 'let _ = ((Foo.div ~children:[x] ()) [@JSX])' | fmt
+  let _ = <Foo.div>x</Foo.div>
+
+Hand-written [@JSX] applications that JSX syntax cannot express are kept as
+regular applications:
+  $ echo 'let _ = ((App.createElement ~children ()) [@JSX])' | fmt
+  let _ = App.createElement ~children () [@JSX]
+  $ echo 'let _ = ((App.createElement ~children:(make_children ()) ()) [@JSX])' | fmt
+  let _ = App.createElement ~children:(make_children ()) () [@JSX]
+  $ echo 'let _ = ((App.createElement ~children:[]) [@JSX])' | fmt
+  let _ = App.createElement ~children:[] [@JSX]
+  $ echo 'let _ = ((App.createElement ()) [@JSX])' | fmt
+  let _ = App.createElement () [@JSX]
+  $ echo 'let _ = ((App.createElement x ~children:[] ()) [@JSX])' | fmt
+  let _ = App.createElement x ~children:[] () [@JSX]
+  $ echo 'let _ = ((App.createElement ~children:[] ~children:[] ()) [@JSX])' | fmt
+  let _ = App.createElement ~children:[] ~children:[] () [@JSX]
+  $ echo 'let _ = (((get_component ()) ~children:[] ()) [@JSX])' | fmt
+  let _ = (get_component ()) ~children:[] () [@JSX]

--- a/vendor/parser-extended/jsx_helper.ml
+++ b/vendor/parser-extended/jsx_helper.ml
@@ -80,3 +80,79 @@ let make_jsx_element ~raise ~loc:_ ~tag ~end_tag ~props ~children () =
   in
   let props = (Labelled {txt="children"; loc=children.pexp_loc}, children) :: props in
   Pexp_apply (tag, (Nolabel, unit) :: props)
+
+(** A [@JSX] application that can be printed with JSX syntax. *)
+type element = {
+  tag : string;
+  tag_loc : Location.t;
+  props : (arg_label * expression) list;
+  children_loc : Location.t;
+  children : expression list;
+}
+
+(** Classify a [@JSX] application. JSX syntax can only express applications
+    of the exact shape produced by [make_jsx_element]: an identifier tag
+    applied to one unlabelled [()] argument, one [~children] argument that
+    is a list literal, and labelled or optional props. Hand-written [@JSX]
+    applications may have any other shape (see
+    ocaml-mlx/ocamlformat-mlx#12), in which case [None] is returned and the
+    application must be printed as a regular application. *)
+let classify_element ~attrs e0 args =
+  let tag =
+    let rec ident_of = function
+      | Lident name -> Some name
+      | Ldot (id, name) ->
+        Option.map (fun path -> path ^ "." ^ name.txt) (ident_of id.txt)
+      | Lapply _ -> None
+    in
+    match e0.pexp_desc with
+    | Pexp_ident { txt = Lident name; loc } -> Some (name, loc)
+    | Pexp_ident { txt = Ldot (id, name); loc = _ } ->
+      Option.map
+        (fun path ->
+          let tag =
+            (* [<Foo />] is parsed as [Foo.createElement]. *)
+            match name.txt with
+            | "createElement" -> path
+            | name -> path ^ "." ^ name
+          in
+          (tag, e0.pexp_loc))
+        (ident_of id.txt)
+    | _ -> None
+  in
+  let units, children, props =
+    List.fold_right
+      (fun arg (units, children, props) ->
+        match arg with
+        | ( Nolabel,
+            { pexp_desc = Pexp_construct ({ txt = Lident "()"; _ }, None);
+              pexp_attributes = [];
+              _ } ) ->
+          (() :: units, children, props)
+        | ( Labelled { txt = "children"; _ },
+            { pexp_desc = Pexp_list es; pexp_attributes = []; pexp_loc; _ } )
+          ->
+          (units, (pexp_loc, es) :: children, props)
+        | ( Labelled { txt = "children"; _ },
+            { pexp_desc = Pexp_construct ({ txt = Lident "[]"; _ }, None);
+              pexp_attributes = [];
+              pexp_loc;
+              _ } ) ->
+          (units, (pexp_loc, []) :: children, props)
+        | arg -> (units, children, arg :: props))
+      args ([], [], [])
+  in
+  let is_prop = function
+    | Labelled { txt = "children"; _ }, _ ->
+      false (* punned or not a list literal *)
+    | (Labelled _ | Optional _), _ -> true
+    | Nolabel, _ -> false
+  in
+  match (attrs, tag, units, children) with
+  | ( [ { attr_name = { txt = "JSX"; _ }; attr_payload = PStr []; _ } ],
+      Some (tag, tag_loc),
+      [ () ],
+      [ (children_loc, children) ] )
+    when List.for_all is_prop props ->
+    Some { tag; tag_loc; props; children_loc; children }
+  | _ -> None


### PR DESCRIPTION
Fixes https://github.com/ocaml-mlx/ocamlformat-mlx/issues/12

ocamlformat-mlx's printer assumed every [@JSX]-attributed application was of kind 1 (canonical shape) and unconditionally printed it back as JSX syntax. For kind 2, that assumption broke — ~children:[] wasn't recognized (printed as a duplicate prop) and the argument order didn't survive the round trip, so the safety check rejected the output.